### PR TITLE
Add klicky modes

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 
   <body>
     <div id="app">
-      <h1>New Change</h1>
+      <h1 data-tracking>New Change</h1>
       <p>Hello World! Open the console to see if Klicky is running</p>
     </div>
     <script src="./src/index.js"></script>

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
 import { Klicky } from "./klicky";
 
-Klicky();
+Klicky('h1');

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
 import { Klicky } from "./klicky";
 
-Klicky('h1');
+Klicky('data-tracking');

--- a/src/klicky.ts
+++ b/src/klicky.ts
@@ -3,7 +3,7 @@ export const Klicky = (selector: string) => {
   document.addEventListener("click", function (evt) {
     // selector mode
     if (selector) {
-
+      // @ts-ignore
       if (selector === evt.target.localName) {
         console.log("SELECTOR MODE");
         console.log(selector + " tag clicked", evt);
@@ -11,6 +11,7 @@ export const Klicky = (selector: string) => {
 
     } else {    // all mode
       console.log("ALL MODE");
+      // @ts-ignore
       console.log(evt.target.localName + " anything clicked", evt);
     }
   })

--- a/src/klicky.ts
+++ b/src/klicky.ts
@@ -4,8 +4,8 @@ export const Klicky = (selector: string) => {
     // selector mode
     if (selector) {
 
-      console.log("SELECTOR MODE");
       if (selector === evt.target.localName) {
+        console.log("SELECTOR MODE");
         console.log(selector + " tag clicked", evt);
       } 
 

--- a/src/klicky.ts
+++ b/src/klicky.ts
@@ -1,3 +1,20 @@
-export const Klicky = () => {
+export const Klicky = (selector: string) => {
+
+  document.addEventListener("click", function (evt) {
+    // selector mode
+    if (selector) {
+
+      console.log("SELECTOR MODE");
+      if (selector === evt.target.localName) {
+        console.log(selector + " tag clicked", evt);
+      } 
+
+    } else {    // all mode
+      console.log("ALL MODE");
+      console.log(evt.target.localName + " anything clicked", evt);
+    }
+  })
+
   console.log("klickly ran!");
 };
+

--- a/src/klicky.ts
+++ b/src/klicky.ts
@@ -1,13 +1,14 @@
-export const Klicky = (selector: string) => {
-
+export const Klicky = (dataSelector: string) => {
   document.addEventListener("click", function (evt) {
     // selector mode
-    if (selector) {
+    if (dataSelector) {
+      const possibleAttr = evt.target.attributes[dataSelector];
+
       // @ts-ignore
-      if (selector === evt.target.localName) {
+      if (possibleAttr != null) {
         console.log("SELECTOR MODE");
-        console.log(selector + " tag clicked", evt);
-      } 
+        console.log(dataSelector + " tag clicked", evt);
+      }
 
     } else {    // all mode
       console.log("ALL MODE");


### PR DESCRIPTION
- Addition of a parameter to the Klicky() function to allow a developer to run the click event listener in two different modes.
- Mode 1: Tracks all click events.
- Mode 2: Filters click events by the data-* attribute specified on a html tag.